### PR TITLE
ダッシュボードに残高表示

### DIFF
--- a/throw-money-app/src/pages/Dashboard.jsx
+++ b/throw-money-app/src/pages/Dashboard.jsx
@@ -6,15 +6,13 @@ const Dashboard = () => {
 
   // state保持データ確認用
   const userName = selector.users.userName
-  const uid = selector.users.uid
-  const isSignIn = selector.users.isSignIn.toString()
+  const remainMoney = selector.users.remainMoney
 
   return (
     <div>
       <h2>ダッシュボード</h2>
       <p>{userName}さん、ようこそ</p>
-      <p>uid : {uid}</p>
-      <p>isSignIn : {isSignIn}</p>
+      <p>残高：{remainMoney}</p>
     </div>
   )
 }

--- a/throw-money-app/src/reducks/store/initialState.js
+++ b/throw-money-app/src/reducks/store/initialState.js
@@ -5,6 +5,7 @@ const initialState = {
     role: '',
     uid: '',
     userName: '',
+    remainMoney: '',
   },
 }
 

--- a/throw-money-app/src/reducks/users/actions.js
+++ b/throw-money-app/src/reducks/users/actions.js
@@ -21,6 +21,7 @@ export const loginAction = (userState) => {
       role: userState.role,
       uid: userState.uid,
       userName: userState.userName,
+      remainMoney: userState.remainMoney,
     },
   }
 }

--- a/throw-money-app/src/reducks/users/operations.js
+++ b/throw-money-app/src/reducks/users/operations.js
@@ -38,10 +38,12 @@ export const pushRegistUser = (username, email, password, confirmPassword) => {
           uid: uid,
           updated_time: timestamp,
           username: username,
+          remainMoney: '0',
         }
 
         // firestoreに登録
-        db.collection('users')
+        return db
+          .collection('users')
           .doc(uid)
           .set(userInitialData)
           .then((result) => {
@@ -94,6 +96,7 @@ export const login = (email, password) => {
                 role: data.role,
                 uid: uid,
                 userName: data.username,
+                remainMoney: data.remainMoney,
               })
             )
             //ダッシュボードへ遷移


### PR DESCRIPTION
ログイン後のダッシュボードにユーザ名。残高を表示するようにしました。
throw-money-app/src/pages/Dashboard.jsx

新規登録したユーザについて、ログイン後、残高が表示されることを確認しました。

ご質問
①課題のダッシュボードとは、単にログイン後のマイページのイメージで良かったでしょうか。
(firebaseの何かの機能を使うのかなとも少し思いましたが、調べても特にヒットしなかったので自力で作成していくものと思っています)

②残高を管理するフィールドをusersドキュメントに追加しましたが、前回課題で登録したユーザのフィールドには残高フィールドが追加されていない状態です。開発中のアプリなので別に困ることはないですが、後学のためこういうケースでのフィールド追加方法について相談させてください。

firestoreコンソールから、usersドキュメント一つ一つに対して手動でフィールド・データ追加はできそうでしたが、ドキュメントが多い場合には使えないかと思います。
以下の様なバッチを作って適用させるしかなさそうでしょうか。
>usersドキュメントからデータ取得>フィールド値が取れない場合は残高フィールドと初期値を追加

（firebaseコンソールでGUIでフィールド・初期値を一括登録できるみたいな機能があればそれでいいのですが）

バッチー公式ガイド
https://firebase.google.com/docs/firestore/manage-data/transactions?hl=ja#batched-writes