### PR TITLE
ダッシュボードにログアウト機能、リダイレクトを実装

### DIFF
--- a/throw-money-app/src/Auth.jsx
+++ b/throw-money-app/src/Auth.jsx
@@ -1,0 +1,28 @@
+import React, { useEffect } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { checkAuthState } from './reducks/users/operations'
+
+const Auth = ({ children }) => {
+  const dispath = useDispatch()
+  const selector = useSelector((state) => state)
+  // storeのstateからログイン状態を取得
+  const isSignIn = selector.users.isSignIn
+
+  // 副作用処理を1回目のマウント時のみ実行
+  useEffect(() => {
+    if (!isSignIn) {
+      // 認証状態のチェック
+      dispath(checkAuthState())
+    }
+  }, [])
+
+  if (!isSignIn) {
+    // 空のJSXを返却
+    return <></>
+  } else {
+    // Router.jsxのAuthの子要素を返却する
+    return children
+  }
+}
+
+export default Auth

--- a/throw-money-app/src/Router.jsx
+++ b/throw-money-app/src/Router.jsx
@@ -1,14 +1,18 @@
 import React from 'react'
 import { Route, Switch } from 'react-router'
 import { Login, RegistUser, Dashboard, Home } from './pages'
+import Auth from './Auth'
 
 const Router = () => {
   return (
     <Switch>
       <Route exact path="/Login" component={Login} />
-      <Route exact path="/Regist" component={RegistUser} />
-      <Route exact path="/Dashboard" component={Dashboard} />
-      <Route exact path="(/)?" component={Home} />
+      <Route exact path="/RegistUser" component={RegistUser} />
+
+      <Auth>
+        <Route exact path="/Dashboard" component={Dashboard} />
+        <Route exact path="(/)?" component={Home} />
+      </Auth>
     </Switch>
   )
 }

--- a/throw-money-app/src/pages/Dashboard.jsx
+++ b/throw-money-app/src/pages/Dashboard.jsx
@@ -1,19 +1,11 @@
 import React from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { push } from 'connected-react-router'
 import { logout } from '../reducks/users/operations'
 import { Button } from '../component/'
 
 const Dashboard = () => {
   const dispatch = useDispatch()
   const selector = useSelector((state) => state)
-  const isSignIn = selector.users.isSignIn
-
-  // 認証されていない場合はログイン画面へリダイレクト
-  if (!isSignIn) {
-    dispatch(push('/Login'))
-  }
-
   // state保持データ確認用
   const userName = selector.users.userName
   const remainMoney = selector.users.remainMoney

--- a/throw-money-app/src/pages/Dashboard.jsx
+++ b/throw-money-app/src/pages/Dashboard.jsx
@@ -1,8 +1,18 @@
 import React from 'react'
 import { useDispatch, useSelector } from 'react-redux'
+import { push } from 'connected-react-router'
+import { logout } from '../reducks/users/operations'
+import { Button } from '../component/'
 
 const Dashboard = () => {
+  const dispatch = useDispatch()
   const selector = useSelector((state) => state)
+  const isSignIn = selector.users.isSignIn
+
+  // 認証されていない場合はログイン画面へリダイレクト
+  if (!isSignIn) {
+    dispatch(push('/Login'))
+  }
 
   // state保持データ確認用
   const userName = selector.users.userName
@@ -13,6 +23,8 @@ const Dashboard = () => {
       <h2>ダッシュボード</h2>
       <p>{userName}さん、ようこそ</p>
       <p>残高：{remainMoney}</p>
+
+      <Button value="ログアウト" onClick={() => dispatch(logout())} />
     </div>
   )
 }

--- a/throw-money-app/src/pages/Login.jsx
+++ b/throw-money-app/src/pages/Login.jsx
@@ -33,7 +33,7 @@ const Login = () => {
 
       <Button value="ログイン" onClick={() => dispatch(login(email, password))} />
 
-      <button onClick={() => dispatch(push('/Regist'))}>新規登録はこちら</button>
+      <button onClick={() => dispatch(push('/RegistUser'))}>新規登録はこちら</button>
     </div>
   )
 }

--- a/throw-money-app/src/reducks/users/actions.js
+++ b/throw-money-app/src/reducks/users/actions.js
@@ -1,5 +1,7 @@
 //Actionタイプ定義
 export const ADD_USER = 'ADD_USER'
+export const LOGIN_USER = 'LOGIN_USER'
+export const LOGOUT_USER = 'LOGOUT_USER'
 
 // ユーザ登録
 export const addUserAction = (userState) => {
@@ -15,7 +17,7 @@ export const addUserAction = (userState) => {
 // ログイン
 export const loginAction = (userState) => {
   return {
-    type: ADD_USER,
+    type: LOGIN_USER,
     payload: {
       isSignIn: true,
       role: userState.role,
@@ -29,13 +31,7 @@ export const loginAction = (userState) => {
 // ログアウト
 export const logoutAction = () => {
   return {
-    type: ADD_USER,
-    payload: {
-      isSignIn: false,
-      role: '',
-      uid: '',
-      userName: '',
-      remainMoney: '',
-    },
+    type: LOGOUT_USER,
+    payload: null,
   }
 }

--- a/throw-money-app/src/reducks/users/actions.js
+++ b/throw-money-app/src/reducks/users/actions.js
@@ -25,3 +25,17 @@ export const loginAction = (userState) => {
     },
   }
 }
+
+// ログアウト
+export const logoutAction = () => {
+  return {
+    type: ADD_USER,
+    payload: {
+      isSignIn: false,
+      role: '',
+      uid: '',
+      userName: '',
+      remainMoney: '',
+    },
+  }
+}

--- a/throw-money-app/src/reducks/users/operations.js
+++ b/throw-money-app/src/reducks/users/operations.js
@@ -1,6 +1,6 @@
 import { auth, db, FirebaseTimestamp } from '../../firebase/index'
 import { push, goBack } from 'connected-react-router'
-import { addUserAction, loginAction } from './actions'
+import { addUserAction, loginAction, logoutAction } from './actions'
 
 // アカウント登録ボタン押下
 export const pushRegistUser = (username, email, password, confirmPassword) => {
@@ -109,5 +109,14 @@ export const login = (email, password) => {
         alert(`ログインが失敗しました。| errorCode:${errorCode}, errorMessage:${errorMessage}`)
         return false
       })
+  }
+}
+
+// ログアウト
+export const logout = () => {
+  return (dispatch) => {
+    dispatch(logoutAction)
+    //ログイン画面へ遷移
+    dispatch(push('/Login'))
   }
 }

--- a/throw-money-app/src/reducks/users/operations.js
+++ b/throw-money-app/src/reducks/users/operations.js
@@ -2,6 +2,42 @@ import { auth, db, FirebaseTimestamp } from '../../firebase/index'
 import { push, goBack } from 'connected-react-router'
 import { addUserAction, loginAction, logoutAction } from './actions'
 
+// 認証状態のチェック
+export const checkAuthState = () => {
+  return (dispatch) => {
+    auth.onAuthStateChanged((user) => {
+      if (user) {
+        const uid = user.uid
+        // ユーザ情報取得
+        db.collection('users')
+          .doc(uid)
+          .get()
+          .then((snapshot) => {
+            // ログイン状態を最新化
+            const data = snapshot.data()
+            dispatch(
+              loginAction({
+                role: data.role,
+                uid: uid,
+                userName: data.username,
+                remainMoney: data.remainMoney,
+              })
+            )
+          })
+          .catch((error) => {
+            const errorCode = error.code
+            const errorMessage = error.message
+            alert(`ユーザ情報の取得が失敗しました。| errorCode:${errorCode}, errorMessage:${errorMessage}`)
+            return false
+          })
+      } else {
+        //ログイン画面へ遷移
+        dispatch(push('/Login'))
+      }
+    })
+  }
+}
+
 // アカウント登録ボタン押下
 export const pushRegistUser = (username, email, password, confirmPassword) => {
   // firestoreにユーザ登録
@@ -115,8 +151,19 @@ export const login = (email, password) => {
 // ログアウト
 export const logout = () => {
   return (dispatch) => {
-    dispatch(logoutAction)
-    //ログイン画面へ遷移
-    dispatch(push('/Login'))
+    auth
+      .signOut()
+      .then(() => {
+        // ログアウトが成功
+        dispatch(logoutAction)
+        //ログイン画面へ遷移
+        dispatch(push('/Login'))
+      })
+      .catch((error) => {
+        const errorCode = error.code
+        const errorMessage = error.message
+        alert(`ログアウトが失敗しました。| errorCode:${errorCode}, errorMessage:${errorMessage}`)
+        return false
+      })
   }
 }

--- a/throw-money-app/src/reducks/users/reducers.js
+++ b/throw-money-app/src/reducks/users/reducers.js
@@ -10,6 +10,16 @@ export const UsersReducer = (state = initialState.users, action) => {
         ...state,
         ...action.payload,
       }
+    case Actions.LOGIN_USER:
+      return {
+        ...state,
+        ...action.payload,
+      }
+    case Actions.LOGOUT_USER:
+      return {
+        ...state,
+        ...action.payload,
+      }
     default:
       return state
   }


### PR DESCRIPTION
ダッシュボードにログアウト機能、リダイレクトを実装しました。

ご質問
①ログアウト機能
storeのisSignIn状態で認証状態を管理する形にしています。
ログアウト時にisSignInをfalseにしてstateを更新しているだけですが、もしfirebase認証周りでなにかしないといけないことがあれば指摘ください。

②リダイレクト
以下で実装しましたが、ログイン後のページが増えるたびに書くことになるので宜しくないかなと考えています。
https://github.com/keiKunn/React-throw-money-app/blob/9ea67dca2b5737985cbca3babfa40ed2e67a023e/throw-money-app/src/pages/Dashboard.jsx#L12-L15

connected-react-routerでのリダイレクトの仕方などについては調べてみましたが、stateの状態を見てリダイレクトしたい場合は各コンポーネントに書くしかないのかなというのが感想です。もしベストプラクティスなものがあればご教授頂きたいです。

参考記事：https://the2g.com/post/quickly-learn-react-router-v4