### PR TITLE
送金機能を実装

### DIFF
--- a/throw-money-app/package-lock.json
+++ b/throw-money-app/package-lock.json
@@ -26,7 +26,8 @@
         "web-vitals": "^1.1.0"
       },
       "devDependencies": {
-        "prettier": "^2.2.1"
+        "prettier": "^2.2.1",
+        "reselect": "^4.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -17344,6 +17345,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "node_modules/reselect": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==",
+      "dev": true
     },
     "node_modules/resolve": {
       "version": "1.18.1",
@@ -35860,6 +35867,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "reselect": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==",
+      "dev": true
     },
     "resolve": {
       "version": "1.18.1",

--- a/throw-money-app/package.json
+++ b/throw-money-app/package.json
@@ -47,6 +47,7 @@
     ]
   },
   "devDependencies": {
-    "prettier": "^2.2.1"
+    "prettier": "^2.2.1",
+    "reselect": "^4.0.0"
   }
 }

--- a/throw-money-app/src/Router.jsx
+++ b/throw-money-app/src/Router.jsx
@@ -4,6 +4,7 @@ import { Login, RegistUser, Dashboard, Home } from './pages'
 import Auth from './Auth'
 
 const Router = () => {
+  console.log('Routerコンポーネント')
   return (
     <Switch>
       <Route exact path="/Login" component={Login} />

--- a/throw-money-app/src/component/Button.jsx
+++ b/throw-money-app/src/component/Button.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 const Button = (props) => {
+  console.log('Buttonコンポーネント')
   return <button onClick={() => props.onClick()}>{props.value}</button>
 }
 

--- a/throw-money-app/src/component/InputTextForm.jsx
+++ b/throw-money-app/src/component/InputTextForm.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 // テキストフォームのコンポーネント
 export const InputTextForm = (props) => {
+  console.log('InputTextFormコンポーネント')
   return (
     <div>
       <label htmlFor={props.name}>

--- a/throw-money-app/src/pages/Dashboard.jsx
+++ b/throw-money-app/src/pages/Dashboard.jsx
@@ -47,19 +47,22 @@ const Dashboard = () => {
     [setSendMoney]
   )
   // 送金実行
-  const handleClickSendMoney = () => {
-    console.log('handleSendMoney:送金実行')
-    if (!sendMoney) {
-      alert('金額を入力してください')
-      return false
-    }
-    dispatch(sendMoneyOperation(uid, modalOtherUserData, sendMoney))
-    // 送金モーダルを閉じる
-    setMpdalIsOpenSend(false)
-    //残高更新
-    console.log('selector.users.remainMoney:' + selector.users.remainMoney)
-    setRemainMoney(selector.users.remainMoney)
-  }
+  const handleClickSendMoney = useCallback(
+    (modalOtherUserData, sendMoney) => {
+      console.log('handleSendMoney:送金実行')
+      if (!sendMoney) {
+        alert('金額を入力してください')
+        return false
+      }
+      dispatch(sendMoneyOperation(uid, modalOtherUserData, sendMoney))
+      // 送金モーダルを閉じる
+      setMpdalIsOpenSend(false)
+      //残高更新
+      console.log('selector.users.remainMoney:' + selector.users.remainMoney)
+      setRemainMoney(selector.users.remainMoney)
+    },
+    [remainMoney, dispatch]
+  )
 
   // 他ユーザ情報
   const [otherUsersInfo, setOtherUsersInfo] = useState([])
@@ -151,7 +154,7 @@ const Dashboard = () => {
           value={sendMoney}
           onChange={inputSendMoney}
         />
-        <Button value="送金実行" onClick={() => handleClickSendMoney()} />
+        <Button value="送金実行" onClick={() => handleClickSendMoney(modalOtherUserData, sendMoney)} />
 
         <p>
           <button onClick={() => setMpdalIsOpenSend(false)}>閉じる</button>

--- a/throw-money-app/src/pages/Dashboard.jsx
+++ b/throw-money-app/src/pages/Dashboard.jsx
@@ -5,6 +5,7 @@ import { logout, sendMoneyOperation } from '../reducks/users/operations'
 import { Button, InputTextForm } from '../component/'
 import Modal from 'react-modal'
 import { modalStyle } from './ModalStyle'
+import { getUserRemainMoney } from '../reducks/users/selectors'
 
 Modal.setAppElement('#root')
 
@@ -15,6 +16,9 @@ const Dashboard = () => {
   const uid = selector.users.uid
   const userName = selector.users.userName
   const [remainMoney, setRemainMoney] = useState(selector.users.remainMoney)
+
+  //const testwallet = getUserRemainMoney(selector)
+  const testwallet = selector.users.remainMoney
 
   // モーダル制御
   // walletを見る
@@ -47,22 +51,38 @@ const Dashboard = () => {
     [setSendMoney]
   )
   // 送金実行
-  const handleClickSendMoney = useCallback(
-    (modalOtherUserData, sendMoney) => {
-      console.log('handleSendMoney:送金実行')
-      if (!sendMoney) {
-        alert('金額を入力してください')
-        return false
-      }
-      dispatch(sendMoneyOperation(uid, modalOtherUserData, sendMoney))
-      // 送金モーダルを閉じる
-      setMpdalIsOpenSend(false)
-      //残高更新
-      console.log('selector.users.remainMoney:' + selector.users.remainMoney)
-      setRemainMoney(selector.users.remainMoney)
-    },
-    [remainMoney, dispatch]
-  )
+  // const handleClickSendMoney = useCallback(
+  //   (modalOtherUserData, sendMoney) => {
+  //     console.log('handleSendMoney:送金実行')
+  //     if (!sendMoney) {
+  //       alert('金額を入力してください')
+  //       return false
+  //     }
+  //     dispatch(sendMoneyOperation(uid, modalOtherUserData, sendMoney))
+  //     // 送金モーダルを閉じる
+  //     setMpdalIsOpenSend(false)
+  //     // ダッシュボードの残高更新
+  //     console.log('selector.users.remainMoney:' + selector.users.remainMoney)
+  //     console.log('testwallet:' + testwallet)
+
+  //     //setRemainMoney(testwallet)
+  //   },
+  //   [testwallet, dispatch]
+  // )
+
+  const handleClickSendMoney = async () => {
+    console.log('handleSendMoney:送金実行')
+    if (!sendMoney) {
+      alert('金額を入力してください')
+      return false
+    }
+    await dispatch(sendMoneyOperation(uid, modalOtherUserData, sendMoney))
+    // 送金モーダルを閉じる
+    setMpdalIsOpenSend(false)
+    // ダッシュボードの残高更新
+    console.log('selector.users.remainMoney:' + selector.users.remainMoney)
+    console.log('testwallet:' + testwallet)
+  }
 
   // 他ユーザ情報
   const [otherUsersInfo, setOtherUsersInfo] = useState([])
@@ -95,7 +115,7 @@ const Dashboard = () => {
     <div>
       <h2>ダッシュボード</h2>
       <p>{userName}さん、ようこそ</p>
-      <p>残高：{remainMoney}</p>
+      <p>残高：{testwallet}</p>
 
       <h3>ユーザ一覧</h3>
       <table>

--- a/throw-money-app/src/pages/Dashboard.jsx
+++ b/throw-money-app/src/pages/Dashboard.jsx
@@ -14,7 +14,7 @@ const Dashboard = () => {
   // state保持データ確認用
   const uid = selector.users.uid
   const userName = selector.users.userName
-  const [remainMoney, setRemnainMoney] = useState(selector.users.remainMoney)
+  const [remainMoney, setRemainMoney] = useState(selector.users.remainMoney)
 
   // モーダル制御
   // walletを見る
@@ -49,7 +49,16 @@ const Dashboard = () => {
   // 送金実行
   const handleClickSendMoney = () => {
     console.log('handleSendMoney:送金実行')
+    if (!sendMoney) {
+      alert('金額を入力してください')
+      return false
+    }
     dispatch(sendMoneyOperation(uid, modalOtherUserData, sendMoney))
+    // 送金モーダルを閉じる
+    setMpdalIsOpenSend(false)
+    //残高更新
+    console.log('selector.users.remainMoney:' + selector.users.remainMoney)
+    setRemainMoney(selector.users.remainMoney)
   }
 
   // 他ユーザ情報

--- a/throw-money-app/src/pages/Dashboard.jsx
+++ b/throw-money-app/src/pages/Dashboard.jsx
@@ -1,8 +1,8 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useCallback, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { db } from '../firebase/index'
-import { logout } from '../reducks/users/operations'
-import { Button } from '../component/'
+import { logout, sendMoneyOperation } from '../reducks/users/operations'
+import { Button, InputTextForm } from '../component/'
 import Modal from 'react-modal'
 import { modalStyle } from './ModalStyle'
 
@@ -14,18 +14,42 @@ const Dashboard = () => {
   // state保持データ確認用
   const uid = selector.users.uid
   const userName = selector.users.userName
-  const remainMoney = selector.users.remainMoney
+  const [remainMoney, setRemnainMoney] = useState(selector.users.remainMoney)
 
   // モーダル制御
-  const [modalIsOpen, setMpdalIsOpen] = useState(false)
+  // walletを見る
+  const [modalIsOpenWatchWallet, setMpdalIsOpenWatchWallet] = useState(false)
   const [modalOtherUserName, setModalOtherUserName] = useState('')
   const [modalOtherUserWallet, setModalOtherUserWallet] = useState('')
+  // 送る
+  const [modalIsOpenSend, setMpdalIsOpenSend] = useState(false)
+  const [sendMoney, setSendMoney] = useState('')
+  const [modalOtherUserData, setModalOtherUserData] = useState('')
 
-  // walletクリックイベント
+  // walletを見る クリックイベント
   const handleClickWallet = (otherUserName, otherUserWallet) => {
-    setMpdalIsOpen(true)
+    setMpdalIsOpenWatchWallet(true)
     setModalOtherUserName(otherUserName)
     setModalOtherUserWallet(otherUserWallet)
+  }
+
+  // 送る クリックイベント
+  // otherUserData:金額の送付先ユーザ情報
+  const handleClickSend = (otherUserData) => {
+    setMpdalIsOpenSend(true)
+    setModalOtherUserData(otherUserData)
+  }
+  // 送る金額 入力イベント
+  const inputSendMoney = useCallback(
+    (event) => {
+      setSendMoney(event.target.value)
+    },
+    [setSendMoney]
+  )
+  // 送金実行
+  const handleClickSendMoney = () => {
+    console.log('handleSendMoney:送金実行')
+    dispatch(sendMoneyOperation(uid, modalOtherUserData, sendMoney))
   }
 
   // 他ユーザ情報
@@ -44,7 +68,7 @@ const Dashboard = () => {
       const otherUserData = doc.data()
       otherUsersInfoTmp.push([
         {
-          id: otherUserData.uid,
+          uid: otherUserData.uid,
           otherUserName: otherUserData.username,
           otherUserWallet: otherUserData.remainMoney,
         },
@@ -70,29 +94,58 @@ const Dashboard = () => {
             <th></th>
           </tr>
           {/**他ユーザ情報の出力*/}
-          {otherUsersInfo.map((userData, index) => {
-            //console.log('userData:' + JSON.stringify(userData))
+          {otherUsersInfo.map((otherUserData, index) => {
+            //console.log('otherUserData:' + JSON.stringify(otherUserData))
             return (
               <tr key={index}>
-                <td>{userData[0].otherUserName}</td>
+                <td>{otherUserData[0].otherUserName}</td>
                 <td>
-                  <button onClick={() => handleClickWallet(userData[0].otherUserName, userData[0].otherUserWallet)}>
-                    walletを見る: {userData[0].otherUserWallet}
-                  </button>
+                  <Button
+                    value="walletを見る"
+                    onClick={() => handleClickWallet(otherUserData[0].otherUserName, otherUserData[0].otherUserWallet)}
+                  />
                 </td>
-                <td>送る</td>
+                <td>
+                  <Button value="送る" onClick={() => handleClickSend(otherUserData[0])} />
+                  {/**
+                   * モーダルの表示
+                   * 表示タイミングで、全ユーザの残金再取得、firestoreに排他処理
+                   *
+                   * 金額入力フォーム
+                   * 送信ボタン
+                   * 送信タイミングで、送信先ユーザの残高更新、排他処理の解除
+                   * 閉じるボタン
+                   * ダッシュボードの更新（再レンダリング） */}
+                </td>
               </tr>
             )
           })}
         </tbody>
       </table>
 
-      {/**モーダルの出力*/}
-      <Modal isOpen={modalIsOpen} style={modalStyle} onRequestClose={() => setMpdalIsOpen(false)}>
+      {/**モーダル：walletを見る*/}
+      <Modal isOpen={modalIsOpenWatchWallet} style={modalStyle} onRequestClose={() => setMpdalIsOpenWatchWallet(false)}>
         <p>ユーザ名：{modalOtherUserName}</p>
         <p>残高：{modalOtherUserWallet}</p>
         <p>
-          <button onClick={() => setMpdalIsOpen(false)}>閉じる</button>
+          <button onClick={() => setMpdalIsOpenWatchWallet(false)}>閉じる</button>
+        </p>
+      </Modal>
+
+      {/**モーダル：送る*/}
+      <Modal isOpen={modalIsOpenSend} style={modalStyle} onRequestClose={() => setMpdalIsOpenSend(false)}>
+        <p>あなたの残高：{remainMoney}</p>
+        <InputTextForm
+          name="sendMoneyForm"
+          labelName="送る金額"
+          type="text"
+          value={sendMoney}
+          onChange={inputSendMoney}
+        />
+        <Button value="送金実行" onClick={() => handleClickSendMoney()} />
+
+        <p>
+          <button onClick={() => setMpdalIsOpenSend(false)}>閉じる</button>
         </p>
       </Modal>
 

--- a/throw-money-app/src/reducks/store/initialState.js
+++ b/throw-money-app/src/reducks/store/initialState.js
@@ -6,7 +6,6 @@ const initialState = {
     uid: '',
     userName: '',
     remainMoney: '',
-    //otherUsersInfo: [],
   },
 }
 

--- a/throw-money-app/src/reducks/users/actions.js
+++ b/throw-money-app/src/reducks/users/actions.js
@@ -1,6 +1,7 @@
 //Actionタイプ定義
 export const ADD_USER = 'ADD_USER'
 export const LOGIN_USER = 'LOGIN_USER'
+export const SEND_MONEY = 'SEND_MONEY'
 export const LOGOUT_USER = 'LOGOUT_USER'
 
 // ユーザ登録
@@ -23,6 +24,16 @@ export const loginAction = (userState) => {
       role: userState.role,
       uid: userState.uid,
       userName: userState.userName,
+      remainMoney: userState.remainMoney,
+    },
+  }
+}
+
+// 送金
+export const sendMoneyAction = (userState) => {
+  return {
+    type: SEND_MONEY,
+    payload: {
       remainMoney: userState.remainMoney,
     },
   }

--- a/throw-money-app/src/reducks/users/actions.js
+++ b/throw-money-app/src/reducks/users/actions.js
@@ -24,7 +24,6 @@ export const loginAction = (userState) => {
       uid: userState.uid,
       userName: userState.userName,
       remainMoney: userState.remainMoney,
-      //otherUsersInfo: userState.otherUsersInfo,
     },
   }
 }

--- a/throw-money-app/src/reducks/users/operations.js
+++ b/throw-money-app/src/reducks/users/operations.js
@@ -151,7 +151,7 @@ export const sendMoneyOperation = (uid, otherUserData, money) => {
         }
       })
     } catch (error) {
-      const errorMessage = error.message
+      const errorMessage = error
       console.log(errorMessage)
       //ダッシュボードへ遷移
       dispatch(push('/Dashboard'))

--- a/throw-money-app/src/reducks/users/reducers.js
+++ b/throw-money-app/src/reducks/users/reducers.js
@@ -15,6 +15,11 @@ export const UsersReducer = (state = initialState.users, action) => {
         ...state,
         ...action.payload,
       }
+    case Actions.SEND_MONEY:
+      return {
+        ...state,
+        ...action.payload,
+      }
     case Actions.LOGOUT_USER:
       return {
         ...state,

--- a/throw-money-app/src/reducks/users/selectors.js
+++ b/throw-money-app/src/reducks/users/selectors.js
@@ -1,0 +1,5 @@
+import { createSelector } from 'reselect'
+
+const usersSelector = (state) => state.users
+
+export const getUserRemainMoney = createSelector([usersSelector], (state) => state.remainMoney)


### PR DESCRIPTION
送金機能を実装しました。

`送金機能実装 transaction実装前`のコミット
送金機能をもつモーダルをダッシュボードに実装しました。
送金実施後、firebaseコンソールから送金先ユーザ・ログインユーザの残高に反映されていることを確認しました。
（課題としては、処理終了後にモーダルが閉じず、ダッシュボードの再レンダリングが実施されない点が残っています。以下記載のトランザクション解決と並行して、取組中です）

`送金機能にトランザクション実装 エラーあり`のコミット
送金先ユーザとログインユーザの残高の整合性を担保するために、トランザクション制御が必要だと考えました。

以下のコード読み込み時にエラーが発生しております。`エラー：Firestore transactions require all reads to be executed before all writes.`
https://github.com/keiKunn/React-throw-money-app/blob/c844c3d872574367f37869f90be948192987600e/throw-money-app/src/reducks/users/operations.js#L132

■質問
二つ以上のドキュメント更新に対して、一つのfirebase.db.transactionは使えない印象を受けました。
（エラー事象について、ネット上で検索かけましたがtransactionを使う方針での解消の方法は見つかりませんでした。）

以下公式ページより、今回のように複数のドキュメントにトランザクションを貼りたい時は、batchを使うという認識でよさそうでしょうか。
https://firebase.google.com/docs/firestore/manage-data/transactions?hl=ja#batched-writes
